### PR TITLE
Null detection for err in getUUID function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,13 @@ function getUUID(url, cb) {
         if (!err && body && body.uuid) {
             cb(null, body.uuid)
         } else {
+            if (err == null) {
+                if (body != null) {
+                    err=body;
+                } else {
+                    err="unknown";
+                }
+            }
             cb(err);
         }
     });


### PR DESCRIPTION
When you get a rate limiting error, err becomes null and body becomes `Too many instances queued.`.This is not caught by the code calling getUUID. Therefore it is handled as successful request causing the following stacktrace afterwards:

```
/usr/lib/node_modules/check_nextcloud/index.js:101`
    let date = result.scannedAt.date.replace(/\.[0-9]{6}$/, '');
                      ^

TypeError: Cannot read property 'scannedAt' of undefined
    at outputResult (/usr/lib/node_modules/check_nextcloud/index.js:101:23)
    at /usr/lib/node_modules/check_nextcloud/index.js:172:17
    at Request._callback (/usr/lib/node_modules/check_nextcloud/index.js:96:9)
    at Request.self.callback (/usr/lib/node_modules/check_nextcloud/node_modules/request/request.js:185:22)
    at emitTwo (events.js:126:13)
    at Request.emit (events.js:214:7)
    at Request.<anonymous> (/usr/lib/node_modules/check_nextcloud/node_modules/request/request.js:1161:10)
    at emitOne (events.js:116:13)
    at Request.emit (events.js:211:7)
    at IncomingMessage.<anonymous> (/usr/lib/node_modules/check_nextcloud/node_modules/request/request.js:1083:12)

```
My pull request fixes this by setting err to the body message when an error is detected. This results in an unknown check result with the corresponding error message.